### PR TITLE
Use a more universal shebang

### DIFF
--- a/vim-bundle
+++ b/vim-bundle
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 bundle_path = "~/.vim/bundle"
 


### PR DESCRIPTION
A lot of people don't use the standard Ruby installed by their OS package manager but use RVM, RBFU and the likes. In this case /usr/bin/ruby does not exist, but resolution via /usr/bin/env ruby should work correctly.
